### PR TITLE
Change Podspec author to Yelp

### DIFF
--- a/YelpAPI.podspec
+++ b/YelpAPI.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.homepage         = "https://github.com/Yelp/yelp-ios"
   s.license          = 'MIT'
-  s.author           = { "David Chen" => "ywchen@yelp.com" }
+  s.author           = 'Yelp'
   s.source           = { :git => "https://github.com/Yelp/yelp-ios.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'


### PR DESCRIPTION
Sorry @d9chen, but it seems like a big name behind this will help with marketing ;)

We've also added [the shared CocoaPods Yelp account](https://cocoapods.org/owners/12085) as an owner (although it's not showing up yet...) so this fixes #13.