### PR TITLE
Add OSX support to the podspec

### DIFF
--- a/YelpAPI.podspec
+++ b/YelpAPI.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/Yelp/yelp-ios.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'
+  s.platform     = :osx, '10.9'
   s.requires_arc = true
 
   s.source_files = "Classes/**/*.{h,m}"


### PR DESCRIPTION
Nothing in here is iOS-specific, so it'll compile and work on OSX as well! All that's stopping us is that the podfile only declares iOS support. This change adds OSX as a supported platform.

I chose 10.9 since that's the version where NSURLSession was introduced, and I can't think of any more-recent dependencies than that.