### PR TITLE
Don't assign platform twice in the podspec

### DIFF
--- a/YelpAPI.podspec
+++ b/YelpAPI.podspec
@@ -22,8 +22,8 @@ Pod::Spec.new do |s|
   s.author           = 'Yelp'
   s.source           = { :git => "https://github.com/Yelp/yelp-ios.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '7.0'
-  s.platform     = :osx, '10.9'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.9'
   s.requires_arc = true
 
   s.source_files = "Classes/**/*.{h,m}"

--- a/YelpAPI.podspec
+++ b/YelpAPI.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "YelpAPI"
-  s.version          = "1.0.3"
+  s.version          = "1.0.4"
   s.summary          = "Objective-C client library for accessing the Yelp Public API."
 
   s.description      = <<-DESC


### PR DESCRIPTION
In #28, I added a second platform declaration to the podfile to declare OSX support. However, the correct way to do this seems to be by instead assigning separate deployment targets; [the docs say](https://guides.cocoapods.org/syntax/podspec.html#platform):
> When supporting multiple platforms you should use deployment_target below instead.

This should fix Yelp/yelp-api#140.