### PR TITLE
Add YLPQuery to allow easier search customization

### DIFF
--- a/Classes/Client/YLPClient+Search.h
+++ b/Classes/Client/YLPClient+Search.h
@@ -54,7 +54,7 @@ typedef void(^YLPSearchCompletionHandler)(YLPSearch *_Nullable search, NSError *
                               sort:(YLPSortType)sort
                  completionHandler:(YLPSearchCompletionHandler)completionHandler;
 
-- (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordiante
+- (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordinate
                  completionHandler:(YLPSearchCompletionHandler)completionHandler;
 
 @end

--- a/Classes/Client/YLPClient+Search.h
+++ b/Classes/Client/YLPClient+Search.h
@@ -12,6 +12,7 @@
 @class YLPCoordinate;
 @class YLPGeoBoundingBox;
 @class YLPGeoCoordinate;
+@class YLPQuery;
 @class YLPSearch;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void(^YLPSearchCompletionHandler)(YLPSearch *_Nullable search, NSError *_Nullable error);
 
 @interface YLPClient (Search)
+
+- (void)searchWithQuery:(YLPQuery *)query
+      completionHandler:(YLPSearchCompletionHandler)completionHandler;
 
 - (void)searchWithLocation:(NSString *)location
                currentLatLong:(nullable YLPCoordinate *)cll

--- a/Classes/Client/YLPClient+Search.m
+++ b/Classes/Client/YLPClient+Search.m
@@ -75,9 +75,9 @@
     [self searchWithQuery:query completionHandler:completionHandler];
 }
 
-- (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordiante
+- (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordinate
                  completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    YLPQuery *query = [[YLPQuery alloc] initWithGeoCoordinate:geoCoordiante];
+    YLPQuery *query = [[YLPQuery alloc] initWithGeoCoordinate:geoCoordinate];
     [self searchWithQuery:query completionHandler:completionHandler];
 }
 

--- a/Classes/Client/YLPClient+Search.m
+++ b/Classes/Client/YLPClient+Search.m
@@ -20,9 +20,8 @@
 
 - (void)searchWithLocation:(NSString *)location
             completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    NSDictionary *params = @{@"location": location};
-    [self searchWithParams:params completionHandler:completionHandler];
+    YLPQuery *query = [[YLPQuery alloc] initWithLocation:location currentLatLong:nil];
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (void)searchWithLocation:(NSString *)location
@@ -32,9 +31,12 @@
                        offset:(NSUInteger)offset
                          sort:(YLPSortType)sort
             completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{@"location": location}];
-    [self buildParamsAndCallSearch:params currentLatLong:cll term:term limit:limit offset:offset sort:sort completionHandler:completionHandler];
+    YLPQuery *query = [[YLPQuery alloc] initWithLocation:location currentLatLong:cll];
+    query.term = term;
+    query.limit = limit;
+    query.offset = offset;
+    query.sort = sort;
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (void)searchWithBounds:(YLPGeoBoundingBox *)bounds
@@ -43,15 +45,19 @@
                      offset:(NSUInteger)offset
                        sort:(YLPSortType)sort
           completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{@"bounds": bounds.description}];
-    [self buildParamsAndCallSearch:params currentLatLong:cll term:term limit:limit offset:offset sort:sort completionHandler:completionHandler];
+    YLPQuery *query = [[YLPQuery alloc] initWithBounds:bounds];
+    query.currentLatLong = cll;
+    query.term = term;
+    query.limit = limit;
+    query.offset = offset;
+    query.sort = sort;
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (void)searchWithBounds:(YLPGeoBoundingBox *)bounds
           completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    [self searchWithBounds:bounds currentLatLong:nil term:nil limit:0 offset:0 sort:0 completionHandler:completionHandler];
+    YLPQuery *query = [[YLPQuery alloc] initWithBounds:bounds];
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordinate
@@ -60,54 +66,19 @@
                             offset:(NSUInteger)offset
                               sort:(YLPSortType)sort
                  completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{@"ll": geoCoordinate.description}];
-    [self buildParamsAndCallSearch:params currentLatLong:cll term:term limit:limit offset:offset sort:sort completionHandler:completionHandler];
+    YLPQuery *query = [[YLPQuery alloc] initWithGeoCoordinate:geoCoordinate];
+    query.currentLatLong = cll;
+    query.term = term;
+    query.limit = limit;
+    query.offset = offset;
+    query.sort = sort;
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (void)searchWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordiante
                  completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    [self searchWithGeoCoordinate:geoCoordiante currentLatLong:nil term:nil limit:0 offset:0 sort:0 completionHandler:completionHandler];
-}
-
-- (void)buildParamsAndCallSearch:(NSMutableDictionary *)params
-                  currentLatLong:(YLPCoordinate *)cll
-                            term:(NSString *)term
-                           limit:(NSUInteger)limit
-                          offset:(NSUInteger)offset
-                            sort:(YLPSortType)sort
-               completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
-    [params addEntriesFromDictionary:[self paramsWithTerm:term currentLatLong:cll limit:limit offset:offset sort:sort]];
-    [self searchWithParams:params completionHandler:completionHandler];
-}
-
-- (NSDictionary *)paramsWithTerm:(NSString *)term
-                       currentLatLong:(YLPCoordinate *)cll
-                                limit:(NSUInteger)limit
-                               offset:(NSUInteger)offset
-                                 sort:(YLPSortType)sort {
-    
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
-    
-    if (cll) {
-        params[@"cll"] = cll.description;
-    }
-    if (term) {
-        params[@"term"] = term;
-    }
-    if (limit) {
-        params[@"limit"] = [NSNumber numberWithInteger:limit];
-    }
-    if (offset) {
-        params[@"offset"] = [NSNumber numberWithInteger:offset];
-    }
-    if (sort) {
-        params[@"sort"] = [NSNumber numberWithInteger:sort];
-    }
-    
-    return params;
+    YLPQuery *query = [[YLPQuery alloc] initWithGeoCoordinate:geoCoordiante];
+    [self searchWithQuery:query completionHandler:completionHandler];
 }
 
 - (NSURLRequest *)searchRequestWithParams:(NSDictionary *)params {
@@ -117,12 +88,6 @@
 - (void)searchWithQuery:(YLPQuery *)query
       completionHandler:(YLPSearchCompletionHandler)completionHandler {
     NSDictionary *params = [query parameters];
-    [self searchWithParams:params completionHandler:completionHandler];
-}
-
-- (void)searchWithParams:(NSDictionary *)params
-          completionHandler:(YLPSearchCompletionHandler)completionHandler {
-    
     NSURLRequest *req = [self searchRequestWithParams:params];
     
     [self queryWithRequest:req completionHandler:^(NSDictionary *responseDict, NSError *error) {

--- a/Classes/Client/YLPClient+Search.m
+++ b/Classes/Client/YLPClient+Search.m
@@ -11,6 +11,8 @@
 #import "YLPCoordinate.h"
 #import "YLPGeoBoundingBox.h"
 #import "YLPGeoCoordinate.h"
+#import "YLPQuery.h"
+#import "YLPQueryPrivate.h"
 #import "YLPResponsePrivate.h"
 #import "YLPClientPrivate.h"
 
@@ -110,6 +112,12 @@
 
 - (NSURLRequest *)searchRequestWithParams:(NSDictionary *)params {
     return [self requestWithPath:@"/v2/search/" params:params];
+}
+
+- (void)searchWithQuery:(YLPQuery *)query
+      completionHandler:(YLPSearchCompletionHandler)completionHandler {
+    NSDictionary *params = [query parameters];
+    [self searchWithParams:params completionHandler:completionHandler];
 }
 
 - (void)searchWithParams:(NSDictionary *)params

--- a/Classes/Request/YLPQuery.h
+++ b/Classes/Request/YLPQuery.h
@@ -1,0 +1,77 @@
+//
+//  YLPQuery.h
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 6/26/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "YLPSortType.h"
+
+@class YLPCoordinate;
+@class YLPGeoBoundingBox;
+@class YLPGeoCoordinate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface YLPQuery : NSObject
+
+/**
+ Initializes a query with a location specified by text.
+ @param location the particular neighborhood, address or city to search in
+ @param cll location as a hint to the geocoder to disambiguate the location text
+ */
+- (instancetype)initWithLocation:(NSString *)location
+                  currentLatLong:(nullable YLPCoordinate *)cll;
+
+/**
+ Initializes a query with a location specified by a geographical bounding box.
+ @param bounds bounds within which to search
+ */
+- (instancetype)initWithBounds:(YLPGeoBoundingBox *)bounds;
+
+/**
+ Initializes a query with a location specified by a geographic coordinate.
+ @param geoCoordinate coordinate around which to search
+ */
+- (instancetype)initWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordinate;
+
+/**
+ Search term (e.g. "food", "restaurants"). If term is nil, everything will be searched.
+ */
+@property (copy, nonatomic, nullable) NSString *term;
+
+/**
+ Number of business results to return. If 0, the API maximum of 20 results will be returned.
+ */
+@property (assign, nonatomic) NSUInteger limit;
+
+/**
+ Amount by which to offset the list of returned business. The default is 0.
+ */
+@property (assign, nonatomic) NSUInteger offset;
+
+/**
+ Sort mode for the list of returned businesses. The default is BestMatched.
+ */
+@property (assign, nonatomic) YLPSortType sort;
+
+/**
+ Aliases of categories to filter search results with. If none, all results will be returned.
+ */
+@property (copy, nonatomic, null_resettable) NSArray<NSString *> *categoryFilter;
+
+/**
+ Search radius in meters. If the value is too large, an AREA_TOO_LARGE error may be returned.
+ */
+@property (assign, nonatomic) double radiusFilter;
+
+/**
+ Whether to exclusively search for businesses with deals.
+ */
+@property (assign, nonatomic) BOOL dealsFilter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Request/YLPQuery.m
+++ b/Classes/Request/YLPQuery.m
@@ -1,0 +1,88 @@
+//
+//  YLPQuery.m
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 6/26/16.
+//
+//
+
+#import "YLPQuery.h"
+#import "YLPQueryPrivate.h"
+#import "YLPCoordinate.h"
+#import "YLPGeoBoundingBox.h"
+#import "YLPGeoCoordinate.h"
+
+@implementation YLPQuery
+
+- (instancetype)initWithLocation:(NSString *)location currentLatLong:(nullable YLPCoordinate *)cll {
+    if (self = [super init]) {
+        _mode = YLPSearchModeLocation;
+        _location = [location copy];
+        _currentLatLong = cll;
+    }
+    return self;
+}
+
+- (instancetype)initWithBounds:(YLPGeoBoundingBox *)bounds {
+    if (self = [super init]) {
+        _mode = YLPSearchModeBounds;
+        _bounds = bounds;
+    }
+    return self;
+}
+
+- (instancetype)initWithGeoCoordinate:(YLPGeoCoordinate *)geoCoordinate {
+    if (self = [super init]) {
+        _mode = YLPSearchModeCoordinate;
+        _geoCoordinate = geoCoordinate;
+    }
+    return self;
+}
+
+- (NSArray<NSString *> *)categoryFilter {
+    return _categoryFilter ?: @[];
+}
+
+- (NSDictionary *)parameters {
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    switch (self.mode) {
+        case YLPSearchModeLocation:
+            params[@"location"] = self.location;
+            break;
+        case YLPSearchModeBounds:
+            params[@"bounds"] = self.bounds.description;
+            break;
+        case YLPSearchModeCoordinate:
+            params[@"ll"] = self.geoCoordinate.description;
+            break;
+    }
+
+    if (self.currentLatLong) {
+        params[@"cll"] = self.currentLatLong.description;
+    }
+    if (self.term) {
+        params[@"term"] = self.term;
+    }
+    if (self.limit) {
+        params[@"limit"] = @(self.limit);
+    }
+    if (self.offset) {
+        params[@"offset"] = @(self.offset);
+    }
+    if (self.sort) {
+        params[@"sort"] = @(self.sort);
+    }
+    if (self.categoryFilter.count > 0) {
+        params[@"category_filter"] = [self.categoryFilter componentsJoinedByString:@","];
+    }
+    if (self.radiusFilter > 0) {
+        params[@"radius_filter"] = @(self.radiusFilter);
+    }
+    if (self.dealsFilter) {
+        params[@"deals_filter"] = @(YES);
+    }
+
+    return params;
+}
+
+@end

--- a/Classes/Request/YLPQueryPrivate.h
+++ b/Classes/Request/YLPQueryPrivate.h
@@ -1,0 +1,31 @@
+//
+//  YLPQueryPrivate.h
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 6/26/16.
+//
+//
+
+#import "YLPQuery.h"
+
+typedef NS_ENUM(NSUInteger, YLPSearchMode) {
+    YLPSearchModeLocation,
+    YLPSearchModeBounds,
+    YLPSearchModeCoordinate,
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface YLPQuery ()
+
+@property (assign, nonatomic) YLPSearchMode mode;
+@property (copy, nonatomic, nullable) NSString *location;
+@property (strong, nonatomic, nullable) YLPCoordinate *currentLatLong;
+@property (strong, nonatomic, nullable) YLPGeoBoundingBox *bounds;
+@property (strong, nonatomic, nullable) YLPGeoCoordinate *geoCoordinate;
+
+- (NSDictionary *)parameters;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/YelpAPI.h
+++ b/Classes/YelpAPI.h
@@ -15,6 +15,7 @@
 
 #import "YLPGeoBoundingBox.h"
 #import "YLPGeoCoordinate.h"
+#import "YLPQuery.h"
 #import "YLPSortType.h"
 
 #import "YLPBusiness.h"

--- a/YelpAPI.xcodeproj/project.pbxproj
+++ b/YelpAPI.xcodeproj/project.pbxproj
@@ -67,6 +67,10 @@
 		134DAA1A1CBF2D1B008DD68F /* phone_search_no_region_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 134DAA0C1CBF2D1B008DD68F /* phone_search_no_region_response.json */; };
 		134DAA1B1CBF2D1B008DD68F /* phone_search_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 134DAA0D1CBF2D1B008DD68F /* phone_search_response.json */; };
 		134DAA1C1CBF2D1B008DD68F /* search_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 134DAA0E1CBF2D1B008DD68F /* search_response.json */; };
+		13BE49641D2037070002262E /* YLPQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 13BE49621D2037070002262E /* YLPQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13BE49651D2037070002262E /* YLPQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE49631D2037070002262E /* YLPQuery.m */; };
+		13BE49671D203E000002262E /* YLPQueryPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 13BE49661D203D6D0002262E /* YLPQueryPrivate.h */; };
+		13BE49691D2056C70002262E /* YLPQueryTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE49681D2056C70002262E /* YLPQueryTestCase.m */; };
 		3A78AC5E6C99BFB7CD1E988E /* Pods_YelpAPITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECEA5945502A068222373C6 /* Pods_YelpAPITests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DF985DF8D644FA5EA0079199 /* Pods_YelpAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6C25E82E1C2E730F4EF2486 /* Pods_YelpAPI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
@@ -145,6 +149,10 @@
 		134DAA0C1CBF2D1B008DD68F /* phone_search_no_region_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = phone_search_no_region_response.json; sourceTree = "<group>"; };
 		134DAA0D1CBF2D1B008DD68F /* phone_search_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = phone_search_response.json; sourceTree = "<group>"; };
 		134DAA0E1CBF2D1B008DD68F /* search_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = search_response.json; sourceTree = "<group>"; };
+		13BE49621D2037070002262E /* YLPQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YLPQuery.h; sourceTree = "<group>"; };
+		13BE49631D2037070002262E /* YLPQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YLPQuery.m; sourceTree = "<group>"; };
+		13BE49661D203D6D0002262E /* YLPQueryPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YLPQueryPrivate.h; sourceTree = "<group>"; };
+		13BE49681D2056C70002262E /* YLPQueryTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YLPQueryTestCase.m; sourceTree = "<group>"; };
 		730313626598E13C8CE0373C /* Pods-YelpAPITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPITests/Pods-YelpAPITests.debug.xcconfig"; sourceTree = "<group>"; };
 		820F5EB4CA0CACBFFCEC2EFF /* Pods-YelpAPI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPI.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPI/Pods-YelpAPI.debug.xcconfig"; sourceTree = "<group>"; };
 		BBEEB4BD98C024A1E0630C57 /* Pods-YelpAPITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPITests/Pods-YelpAPITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -250,6 +258,9 @@
 				134DA9911CBF253B008DD68F /* YLPGeoBoundingBox.m */,
 				134DA9921CBF253B008DD68F /* YLPGeoCoordinate.h */,
 				134DA9931CBF253B008DD68F /* YLPGeoCoordinate.m */,
+				13BE49621D2037070002262E /* YLPQuery.h */,
+				13BE49631D2037070002262E /* YLPQuery.m */,
+				13BE49661D203D6D0002262E /* YLPQueryPrivate.h */,
 				134DA9941CBF253B008DD68F /* YLPSortType.h */,
 			);
 			path = Request;
@@ -337,6 +348,7 @@
 			children = (
 				134DAA061CBF2D1B008DD68F /* YLPGeoBoundingBoxTestCase.m */,
 				134DAA071CBF2D1B008DD68F /* YLPGeoCoordinateTestCase.m */,
+				13BE49681D2056C70002262E /* YLPQueryTestCase.m */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -382,6 +394,8 @@
 				134DA9BD1CBF253B008DD68F /* YLPGeoBoundingBox.h in Headers */,
 				134DA9B11CBF253B008DD68F /* YLPClient+Business.h in Headers */,
 				134DA9B31CBF253B008DD68F /* YLPClient+PhoneSearch.h in Headers */,
+				13BE49641D2037070002262E /* YLPQuery.h in Headers */,
+				13BE49671D203E000002262E /* YLPQueryPrivate.h in Headers */,
 				134DA9D21CBF253B008DD68F /* YLPPhoneSearch.h in Headers */,
 				134DA9B91CBF253B008DD68F /* YLPClientPrivate.h in Headers */,
 				134DA9D61CBF253B008DD68F /* YLPResponsePrivate.h in Headers */,
@@ -581,6 +595,7 @@
 				134DA9CF1CBF253B008DD68F /* YLPGiftCertificateOption.m in Sources */,
 				134DA9B21CBF253B008DD68F /* YLPClient+Business.m in Sources */,
 				134DA9DA1CBF253B008DD68F /* YLPSearch.m in Sources */,
+				13BE49651D2037070002262E /* YLPQuery.m in Sources */,
 				134DA9B41CBF253B008DD68F /* YLPClient+PhoneSearch.m in Sources */,
 				134DA9D81CBF253B008DD68F /* YLPReview.m in Sources */,
 				134DA9C01CBF253B008DD68F /* YLPGeoCoordinate.m in Sources */,
@@ -607,6 +622,7 @@
 				134DAA111CBF2D1B008DD68F /* YLPClientTestCaseBase.m in Sources */,
 				134DAA0F1CBF2D1B008DD68F /* YLPBusinessClientTestCase.m in Sources */,
 				134DAA151CBF2D1B008DD68F /* YLPGeoBoundingBoxTestCase.m in Sources */,
+				13BE49691D2056C70002262E /* YLPQueryTestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YelpAPITests/Client/YLPSearchClientTestCase.m
+++ b/YelpAPITests/Client/YLPSearchClientTestCase.m
@@ -24,72 +24,11 @@
 @interface YLPSearchClientTestCase : YLPClientTestCaseBase
 @end
 
-@interface YLPClient (SearchTest)
-- (void)searchWithParams:(NSDictionary *)params completionHandler:(void (^)(YLPSearch *search, NSError *error))completionHandler;
-@end
-
 @implementation YLPSearchClientTestCase
 
 - (void)setUp {
     [super setUp];
     self.defaultResource = @"search_response.json";
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-- (id)mockSearchRequestWithAllArgs {
-    id mockSearchRequestWithAllArgs = OCMPartialMock(self.client);
-    OCMStub([mockSearchRequestWithAllArgs searchWithParams:[OCMArg any] completionHandler:[OCMArg any]]);
-    
-    return mockSearchRequestWithAllArgs;
-    
-}
-
-- (void)testGetSearchWithTermCreatesExpectedParams {
-    id mockSearchRequestWithAllArgs = [self mockSearchRequestWithAllArgs];
-    NSString *location = @"San Fransokyo";
-    NSString *expectedTerm = @"some test term";
-    double expectedLat = 30.1112322223;
-    double expectedLong = -122.332322199980;
-    YLPCoordinate *cll = [[YLPCoordinate alloc] initWithLatitude:expectedLat longitude:expectedLong];
-    NSUInteger expectedLimit = 3;
-    [self.client searchWithLocation:location currentLatLong:cll term:expectedTerm limit:expectedLimit offset:0 sort:YLPSortTypeBestMatched completionHandler:^(YLPSearch *search, NSError *error) {}];
-    
-    
-    NSDictionary *expectedDict = @{@"term": expectedTerm, @"limit": [NSNumber numberWithInteger:expectedLimit], @"location": location, @"cll": cll.description};
-    OCMExpect([mockSearchRequestWithAllArgs searchWithParams:expectedDict completionHandler:[OCMArg any]]);
-}
-
-- (void)testGetSearchWithLocationCreatesExpectedParams {
-    id mockSearchRequestWithAllArgs = [self mockSearchRequestWithAllArgs];
-    NSString *location = @"San Fransokyo";
-    [self.client searchWithLocation:location completionHandler:^(YLPSearch *search, NSError *error) {}];
-    
-    OCMExpect([mockSearchRequestWithAllArgs searchWithParams:@{@"location": location} completionHandler:[OCMArg any]]);
-    
-}
-
-- (void)testGetSearchWithBoundsCreatesExpectedParams {
-    id mockSearchRequestWithAllArgs = [self mockSearchRequestWithAllArgs];
-    
-    YLPGeoBoundingBox *bounds = [[YLPGeoBoundingBox alloc] initWithSouthWestLongitude:1 southWestLatitude:1.2 northEastLatitude:1.3 northEastLongitude:1.5];
-    [self.client searchWithBounds:bounds completionHandler:^(YLPSearch *search, NSError *error) {}];
-    
-    OCMExpect([mockSearchRequestWithAllArgs searchWithParams:@{@"bounds": bounds} completionHandler:[OCMArg any]]);
-}
-
-- (void)testGetSearchWithGeoCoordCreatesExpectedParams {
-    id mockSearchRequestWithAllArgs = [self mockSearchRequestWithAllArgs];
-    
-    YLPGeoCoordinate *coordinate = [[YLPGeoCoordinate alloc] initWithLatitude:10 longitude:20 accuracy:15 altitude:12 altitudeAccuracy:1];
-    
-    [self.client searchWithGeoCoordinate:coordinate completionHandler:^(YLPSearch *search, NSError *error) {}];
-    
-    OCMExpect([mockSearchRequestWithAllArgs searchWithParams:@{@"ll": coordinate} completionHandler:[OCMArg any]]);
-    
 }
 
 - (void)testGetSearchSuccess {

--- a/YelpAPITests/Request/YLPQueryTestCase.m
+++ b/YelpAPITests/Request/YLPQueryTestCase.m
@@ -1,0 +1,70 @@
+//
+//  YLPQueryTestCase.m
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 6/26/16.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "YLPCoordinate.h"
+#import "YLPGeoBoundingBox.h"
+#import "YLPGeoCoordinate.h"
+#import "YLPQuery.h"
+#import "YLPQueryPrivate.h"
+
+@interface YLPQueryTestCase : XCTestCase
+@end
+
+@implementation YLPQueryTestCase
+
+- (void)testQueryWithTerm {
+    NSString *location = @"San Fransokyo";
+    NSString *expectedTerm = @"some test term";
+    double expectedLat = 30.1112322223;
+    double expectedLong = -122.332322199980;
+    YLPCoordinate *cll = [[YLPCoordinate alloc] initWithLatitude:expectedLat longitude:expectedLong];
+    NSUInteger expectedLimit = 3;
+
+    YLPQuery *query = [[YLPQuery alloc] initWithLocation:location currentLatLong:cll];
+    query.term = expectedTerm;
+    query.limit = expectedLimit;
+
+    NSDictionary *expectedParams = @{
+        @"term": expectedTerm,
+        @"limit": @(expectedLimit),
+        @"location": location,
+        @"cll": cll.description,
+    };
+    XCTAssertEqualObjects([query parameters], expectedParams);
+}
+
+- (void)testQueryWithBounds {
+    YLPGeoBoundingBox *bounds = [[YLPGeoBoundingBox alloc] initWithSouthWestLongitude:1 southWestLatitude:1.2 northEastLatitude:1.3 northEastLongitude:1.5];
+    YLPQuery *query = [[YLPQuery alloc] initWithBounds:bounds];
+
+    NSDictionary *expectedParams = @{@"bounds": bounds.description};
+    XCTAssertEqualObjects([query parameters], expectedParams);
+}
+
+- (void)testQueryWithGeoCoordinate {
+    YLPGeoCoordinate *coordinate = [[YLPGeoCoordinate alloc] initWithLatitude:10 longitude:20 accuracy:15 altitude:12 altitudeAccuracy:1];
+    YLPQuery *query = [[YLPQuery alloc] initWithGeoCoordinate:coordinate];
+
+    NSDictionary *expectedParams = @{@"ll": coordinate.description};
+    XCTAssertEqualObjects([query parameters], expectedParams);
+}
+
+- (void)testQueryWithCategoryFilter {
+    NSString *location = @"San Fransokyo";
+    YLPQuery *query = [[YLPQuery alloc] initWithLocation:location currentLatLong:nil];
+    query.categoryFilter = @[@"bars", @"french"];
+
+    NSDictionary *expectedParams = @{
+        @"location": location,
+        @"category_filter": @"bars,french",
+    };
+    XCTAssertEqualObjects([query parameters], expectedParams);
+}
+
+@end


### PR DESCRIPTION
We got a request to allow specifying category filters for searches (#34, originally mentioned in #33). With the existing architecture this is a little painful; we'd need to add new methods for location text search, bounds search, and coordinate search, and anyone calling these methods would have to provide the default values for every parameter they don't care about.

We can fix this by extracting the search parameters into a separate object, here named `YLPQuery`. This allows us to initialize all parameters with the default values and then allow users to overwrite the ones they want to change. We can support the three different ways of specifying location as just three different initializers.

This extracts some logic into a more testable object, and so I've moved most of the YLPClient+Search tests. The existing tests weren't actually working because OCMock doesn't appear to actually check dictionaries for equality in expectations :/

All this means it's easy to add our other optional parameters, so this adds support for `category_filter`, `radius_filter`, and `deals_filter`.

This fixes #34.