### PR TITLE
Share a single client in the example app

### DIFF
--- a/Example/YelpAPI/YLPAppDelegate.h
+++ b/Example/YelpAPI/YLPAppDelegate.h
@@ -8,8 +8,12 @@
 
 @import UIKit;
 
+@class YLPClient;
+
 @interface YLPAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
+
++ (YLPClient *)sharedClient;
 
 @end

--- a/Example/YelpAPI/YLPAppDelegate.m
+++ b/Example/YelpAPI/YLPAppDelegate.m
@@ -7,40 +7,25 @@
 //
 
 #import "YLPAppDelegate.h"
+#import "YLPClient+ClientSetup.h"
+
+@interface YLPAppDelegate ()
+@property (strong, nonatomic) YLPClient *client;
+@end
 
 @implementation YLPAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-    // Override point for customization after application launch.
++ (YLPClient *)sharedClient {
+    YLPAppDelegate *appDelegate = (YLPAppDelegate *)[UIApplication sharedApplication].delegate;
+    return appDelegate.client;
+}
+
+#pragma mark UIApplicationDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.client = [YLPClient newClient];
+
     return YES;
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/Example/YelpAPI/YLPBusinessViewController.m
+++ b/Example/YelpAPI/YLPBusinessViewController.m
@@ -8,12 +8,11 @@
 
 #import "YLPBusinessViewController.h"
 #import "YLPDetailBusinessViewController.h"
-#import "YLPClient+ClientSetup.h"
+#import "YLPAppDelegate.h"
 #import <YelpAPI/YLPClient+Business.h>
 #import <YelpAPI/YLPBusiness.h>
 
 @interface YLPBusinessViewController ()
-@property (nonatomic) YLPClient *client;
 @property (nonatomic) YLPBusiness *business;
 
 @end
@@ -22,9 +21,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.client = [YLPClient newClient];
     
-    [self.client businessWithId:@"gary-danko-san-francisco" completionHandler:^
+    [[YLPAppDelegate sharedClient] businessWithId:@"gary-danko-san-francisco" completionHandler:^
         (YLPBusiness *business, NSError* error) {
             self.business = business;
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/Example/YelpAPI/YLPPhoneSearchTableViewController.m
+++ b/Example/YelpAPI/YLPPhoneSearchTableViewController.m
@@ -8,13 +8,12 @@
 
 #import "YLPPhoneSearchTableViewController.h"
 #import "YLPDetailBusinessViewController.h"
-#import "YLPClient+ClientSetup.h"
+#import "YLPAppDelegate.h"
 #import <YelpAPI/YLPClient+PhoneSearch.h>
 #import <YelpAPI/YLPPhoneSearch.h>
 #import <YelpAPI/YLPBusiness.h>
 
 @interface YLPPhoneSearchTableViewController ()
-@property (nonatomic) YLPClient *client;
 @property (nonatomic) YLPPhoneSearch *phoneSearch;
 @property (nonatomic) NSError *error;
 @end
@@ -23,10 +22,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.client = [YLPClient newClient];
     
     // Purposefully issue an invalid request.
-    [self.client businessWithPhoneNumber:@"+++4158759656" completionHandler:^
+    [[YLPAppDelegate sharedClient] businessWithPhoneNumber:@"+++4158759656" completionHandler:^
         (YLPPhoneSearch *phoneSearch, NSError* error) {
             self.error = error;
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/Example/YelpAPI/YLPSearchTableViewController.m
+++ b/Example/YelpAPI/YLPSearchTableViewController.m
@@ -8,14 +8,13 @@
 
 #import "YLPSearchTableViewController.h"
 #import "YLPDetailBusinessViewController.h"
-#import "YLPClient+ClientSetup.h"
+#import "YLPAppDelegate.h"
 #import <YelpAPI/YLPClient+Search.h>
 #import <YelpAPI/YLPSortType.h>
 #import <YelpAPI/YLPSearch.h>
 #import <YelpAPI/YLPBusiness.h>
 
 @interface YLPSearchTableViewController ()
-@property (nonatomic) YLPClient *client;
 @property (nonatomic) YLPSearch *search;
 @end
 
@@ -23,9 +22,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.client = [YLPClient newClient];
     
-    [self.client searchWithLocation:@"San Francisco, CA" currentLatLong:nil term:nil limit:5 offset:0 sort:YLPSortTypeDistance completionHandler:^
+    [[YLPAppDelegate sharedClient] searchWithLocation:@"San Francisco, CA" currentLatLong:nil term:nil limit:5 offset:0 sort:YLPSortTypeDistance completionHandler:^
         (YLPSearch *search, NSError* error) {
             self.search = search;
             dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Currently, every different page of the example app instantiates its own client. This isn't necessary and will be problematic for API v3, where creating a client requires a network request to first get an access token. So, as some prep refactor, we can make all the pages share a client.

I accomplished this by making the client a singleton that lives on the app delegate. (I considered having it be passed into each view controller as it's pushed, but the sample app uses storyboards and I'm not totally sure how to go about that change...)