### PR TITLE
Add reviews lookup for API v3

### DIFF
--- a/Classes/Client/YLPClient+Reviews.h
+++ b/Classes/Client/YLPClient+Reviews.h
@@ -1,0 +1,28 @@
+//
+//  YLPClient+Reviews.h
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 10/21/16.
+//
+//
+
+#import "YLPClient.h"
+
+@class YLPBusinessReviews;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^YLPReviewsCompletionHandler)(YLPBusinessReviews *_Nullable reviews, NSError *_Nullable error);
+
+@interface YLPClient (Reviews)
+
+- (void)reviewsForBusinessWithId:(NSString *)businessId
+               completionHandler:(YLPReviewsCompletionHandler)completionHandler;
+
+- (void)reviewsForBusinessWithId:(NSString *)businessId
+                          locale:(nullable NSString *)locale
+               completionHandler:(YLPReviewsCompletionHandler)completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Client/YLPClient+Reviews.m
+++ b/Classes/Client/YLPClient+Reviews.m
@@ -1,0 +1,37 @@
+//
+//  YLPClient+Reviews.m
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 10/21/16.
+//
+//
+
+#import "YLPClient+Reviews.h"
+#import "YLPClientPrivate.h"
+#import "YLPResponsePrivate.h"
+
+@implementation YLPClient (Reviews)
+
+- (void)reviewsForBusinessWithId:(NSString *)businessId
+               completionHandler:(YLPReviewsCompletionHandler)completionHandler {
+    [self reviewsForBusinessWithId:businessId locale:nil completionHandler:completionHandler];
+}
+
+- (void)reviewsForBusinessWithId:(NSString *)businessId
+                          locale:(nullable NSString *)locale
+               completionHandler:(YLPReviewsCompletionHandler)completionHandler {
+    NSString *path = [NSString stringWithFormat:@"/v3/businesses/%@/reviews", businessId];
+    NSDictionary *params = locale ? @{@"locale": locale} : @{};
+    NSURLRequest *request = [self requestWithPath:path params:params];
+
+    [self queryWithRequest:request completionHandler:^(NSDictionary *responseDict, NSError *error) {
+        if (error) {
+            completionHandler(nil, error);
+        } else {
+            YLPBusinessReviews *reviews = [[YLPBusinessReviews alloc] initWithDictionary:responseDict];
+            completionHandler(reviews, nil);
+        }
+    }];
+}
+
+@end

--- a/Classes/Response/YLPBusinessReviews.h
+++ b/Classes/Response/YLPBusinessReviews.h
@@ -1,0 +1,22 @@
+//
+//  YLPBusinessReviews.h
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 10/21/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@class YLPReview;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface YLPBusinessReviews : NSObject
+
+@property (nonatomic, readonly) NSArray<YLPReview *> *reviews;
+@property (nonatomic, readonly) NSUInteger total;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Response/YLPBusinessReviews.m
+++ b/Classes/Response/YLPBusinessReviews.m
@@ -1,0 +1,30 @@
+//
+//  YLPBusinessReviews.m
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 10/21/16.
+//
+//
+
+#import "YLPBusinessReviews.h"
+#import "YLPResponsePrivate.h"
+
+@implementation YLPBusinessReviews
+
+- (instancetype)initWithDictionary:(NSDictionary *)reviewsDict {
+    if (self = [super init]) {
+        _total = [reviewsDict[@"total"] unsignedIntegerValue];
+        _reviews = [self.class reviewsFromJSONArray:reviewsDict[@"reviews"]];
+    }
+    return self;
+}
+
++ (NSArray *)reviewsFromJSONArray:(NSArray *)reviewsJSON {
+    NSMutableArray<YLPReview *> *reviews = [[NSMutableArray alloc] init];
+    for (NSDictionary *review in reviewsJSON) {
+        [reviews addObject:[[YLPReview alloc] initWithDictionary:review]];
+    }
+    return reviews;
+}
+
+@end

--- a/Classes/Response/YLPResponsePrivate.h
+++ b/Classes/Response/YLPResponsePrivate.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface YLPUser ()
-- (instancetype)initWithName:(NSString *)name identifier:(NSString *)identifier imageURLString:(NSURL *)imageURLString;
+- (instancetype)initWithDictionary:(NSDictionary *)userDict;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Response/YLPResponsePrivate.h
+++ b/Classes/Response/YLPResponsePrivate.h
@@ -6,6 +6,7 @@
 //
 //
 #import "YLPBusiness.h"
+#import "YLPBusinessReviews.h"
 #import "YLPCategory.h"
 #import "YLPLocation.h"
 #import "YLPReview.h"
@@ -16,6 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YLPBusiness ()
 - (instancetype)initWithDictionary:(NSDictionary *)businessDict;
+@end
+
+@interface YLPBusinessReviews ()
+- (instancetype)initWithDictionary:(NSDictionary *)reviewsDict;
 @end
 
 @interface YLPCategory ()

--- a/Classes/Response/YLPReview.h
+++ b/Classes/Response/YLPReview.h
@@ -21,10 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) double rating;
 
-@property(nonatomic, readonly, copy) NSURL *ratingImageURL;
-@property(nonatomic, readonly, copy) NSURL *ratingImageSmallURL;
-@property(nonatomic, readonly, copy) NSURL *ratingImageLargeURL;
-
 @property(nonatomic, readonly, copy) YLPUser *user;
 
 @end

--- a/Classes/Response/YLPReview.m
+++ b/Classes/Response/YLPReview.m
@@ -15,17 +15,24 @@
 - (instancetype)initWithDictionary:(NSDictionary *)reviewDict {
     if (self = [super init]) {
         _rating = [reviewDict[@"rating"] doubleValue];
-        _excerpt = reviewDict[@"excerpt"];
-        _timeCreated = [NSDate dateWithTimeIntervalSince1970:[reviewDict[@"time_created"] doubleValue]];
-        _ratingImageURL = [NSURL URLWithString:reviewDict[@"rating_image_url"]];
-        _ratingImageSmallURL = [NSURL URLWithString:reviewDict[@"rating_image_small_url"]];
-        _ratingImageLargeURL = [NSURL URLWithString:reviewDict[@"rating_image_large_url"]];
-        
-        _user = [[YLPUser alloc] initWithName:reviewDict[@"user"][@"name"] identifier:reviewDict[@"user"][@"id"] imageURLString:reviewDict[@"user"][@"image_url"]];
-        
+        _excerpt = reviewDict[@"text"];
+        _timeCreated = [self.class dateFromTimestamp:reviewDict[@"time_created"]];
+        _user = [[YLPUser alloc] initWithDictionary:reviewDict[@"user"]];
     }
     
     return self;
+}
+
++ (NSDate *)dateFromTimestamp:(NSString *)timestamp {
+    static NSDateFormatter *dateFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.dateFormat = @"yyyy-MM-dd' 'HH:mm:ss";
+        dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"PST"];
+    });
+
+    return [dateFormatter dateFromString:timestamp];
 }
 
 @end

--- a/Classes/Response/YLPUser.h
+++ b/Classes/Response/YLPUser.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YLPUser : NSObject
 
-@property (nonatomic, copy, readonly) NSString *identifier;
 @property (nonatomic, copy, readonly) NSString *name;
 
 @property (nonatomic, copy, nullable, readonly) NSURL *imageURL;

--- a/Classes/Response/YLPUser.m
+++ b/Classes/Response/YLPUser.m
@@ -10,11 +10,15 @@
 
 @implementation YLPUser
 
-- (instancetype)initWithName:(NSString *)name identifier:(NSString *)identifier imageURLString:(NSString *)imageURLString {
+- (instancetype)initWithDictionary:(NSDictionary *)userDict {
     if (self = [super init]) {
-        _identifier = identifier;
-        _name = name;
-        _imageURL = imageURLString ? [NSURL URLWithString:imageURLString] : nil;
+        _name = userDict[@"name"];
+        id imageURL = userDict[@"image_url"];
+        if (imageURL && ![imageURL isEqual:[NSNull null]]) {
+            _imageURL = [NSURL URLWithString:imageURL];
+        } else {
+            _imageURL = nil;
+        }
     }
     return self;
 }

--- a/Classes/YelpAPI.h
+++ b/Classes/YelpAPI.h
@@ -9,6 +9,7 @@
 #import "YLPClient.h"
 #import "YLPClient+Business.h"
 #import "YLPClient+PhoneSearch.h"
+#import "YLPClient+Reviews.h"
 #import "YLPClient+Search.h"
 
 #import "YLPCoordinate.h"
@@ -17,6 +18,7 @@
 #import "YLPSortType.h"
 
 #import "YLPBusiness.h"
+#import "YLPBusinessReviews.h"
 #import "YLPCategory.h"
 #import "YLPLocation.h"
 #import "YLPReview.h"

--- a/YelpAPI.xcodeproj/project.pbxproj
+++ b/YelpAPI.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		130408DF1DBA96F200E44AC6 /* reviews_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 130408DE1DBA96F200E44AC6 /* reviews_response.json */; };
+		130408EE1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130408ED1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift */; };
 		134DA8BD1CBF2484008DD68F /* YelpAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 134DA8BC1CBF2484008DD68F /* YelpAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		134DA9B11CBF253B008DD68F /* YLPClient+Business.h in Headers */ = {isa = PBXBuildFile; fileRef = 134DA9821CBF253B008DD68F /* YLPClient+Business.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		134DA9B21CBF253B008DD68F /* YLPClient+Business.m in Sources */ = {isa = PBXBuildFile; fileRef = 134DA9831CBF253B008DD68F /* YLPClient+Business.m */; };
@@ -98,6 +100,9 @@
 
 /* Begin PBXFileReference section */
 		002DB8E26156F1C9C8A09B36 /* Pods-YelpAPITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPITests/Pods-YelpAPITests.debug.xcconfig"; sourceTree = "<group>"; };
+		130408DE1DBA96F200E44AC6 /* reviews_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reviews_response.json; sourceTree = "<group>"; };
+		130408EC1DBC0D7B00E44AC6 /* YelpAPITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "YelpAPITests-Bridging-Header.h"; sourceTree = "<group>"; };
+		130408ED1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YLPReviewsClientTestCase.swift; sourceTree = "<group>"; };
 		134DA8B91CBF2484008DD68F /* YelpAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YelpAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		134DA8BC1CBF2484008DD68F /* YelpAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YelpAPI.h; sourceTree = "<group>"; };
 		134DA8BE1CBF2484008DD68F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -322,6 +327,7 @@
 				134DAA051CBF2D1B008DD68F /* Request */,
 				134DAA081CBF2D1B008DD68F /* Responses */,
 				134DA9F51CBF2CC2008DD68F /* Info.plist */,
+				130408EC1DBC0D7B00E44AC6 /* YelpAPITests-Bridging-Header.h */,
 			);
 			path = YelpAPITests;
 			sourceTree = "<group>";
@@ -334,6 +340,7 @@
 				134DA9FF1CBF2D1B008DD68F /* YLPClientTestCaseBase.h */,
 				134DAA001CBF2D1B008DD68F /* YLPClientTestCaseBase.m */,
 				134DAA011CBF2D1B008DD68F /* YLPPhoneSearchClientTestCase.m */,
+				130408ED1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift */,
 				134DAA021CBF2D1B008DD68F /* YLPSearchClientTestCase.m */,
 			);
 			path = Client;
@@ -361,6 +368,7 @@
 				134DAA091CBF2D1B008DD68F /* business_response.json */,
 				134DAA0A1CBF2D1B008DD68F /* error.json */,
 				134DAA0D1CBF2D1B008DD68F /* phone_search_response.json */,
+				130408DE1DBA96F200E44AC6 /* reviews_response.json */,
 				134DAA0E1CBF2D1B008DD68F /* search_response.json */,
 			);
 			path = Responses;
@@ -519,6 +527,7 @@
 					};
 					134DA9F01CBF2CC2008DD68F = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 					13640F141DB2C7ED005F551B = {
 						CreatedOnToolsVersion = 8.0;
@@ -561,6 +570,7 @@
 				134DAA1C1CBF2D1B008DD68F /* search_response.json in Resources */,
 				134DAA181CBF2D1B008DD68F /* error.json in Resources */,
 				134DAA171CBF2D1B008DD68F /* business_response.json in Resources */,
+				130408DF1DBA96F200E44AC6 /* reviews_response.json in Resources */,
 				134DAA1B1CBF2D1B008DD68F /* phone_search_response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -725,6 +735,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				134DAA131CBF2D1B008DD68F /* YLPSearchClientTestCase.m in Sources */,
+				130408EE1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift in Sources */,
 				134DAA141CBF2D1B008DD68F /* YLPCoordinateTestCase.m in Sources */,
 				134DAA101CBF2D1B008DD68F /* YLPClientTestCase.m in Sources */,
 				134DAA121CBF2D1B008DD68F /* YLPPhoneSearchClientTestCase.m in Sources */,
@@ -798,6 +809,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -822,6 +834,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -923,6 +936,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.yelp.YelpAPITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "YelpAPITests/YelpAPITests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -947,6 +962,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.yelp.YelpAPITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "YelpAPITests/YelpAPITests-Bridging-Header.h";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/YelpAPI.xcodeproj/project.pbxproj
+++ b/YelpAPI.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		130408DF1DBA96F200E44AC6 /* reviews_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 130408DE1DBA96F200E44AC6 /* reviews_response.json */; };
+		130408E41DBAAA4600E44AC6 /* YLPClient+Reviews.h in Headers */ = {isa = PBXBuildFile; fileRef = 130408E21DBAAA4600E44AC6 /* YLPClient+Reviews.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		130408E51DBAAA4600E44AC6 /* YLPClient+Reviews.m in Sources */ = {isa = PBXBuildFile; fileRef = 130408E31DBAAA4600E44AC6 /* YLPClient+Reviews.m */; };
+		130408E81DBAB04400E44AC6 /* YLPBusinessReviews.h in Headers */ = {isa = PBXBuildFile; fileRef = 130408E61DBAB04400E44AC6 /* YLPBusinessReviews.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		130408E91DBAB04400E44AC6 /* YLPBusinessReviews.m in Sources */ = {isa = PBXBuildFile; fileRef = 130408E71DBAB04400E44AC6 /* YLPBusinessReviews.m */; };
 		130408EE1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130408ED1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift */; };
 		134DA8BD1CBF2484008DD68F /* YelpAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 134DA8BC1CBF2484008DD68F /* YelpAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		134DA9B11CBF253B008DD68F /* YLPClient+Business.h in Headers */ = {isa = PBXBuildFile; fileRef = 134DA9821CBF253B008DD68F /* YLPClient+Business.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -101,6 +105,10 @@
 /* Begin PBXFileReference section */
 		002DB8E26156F1C9C8A09B36 /* Pods-YelpAPITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPITests/Pods-YelpAPITests.debug.xcconfig"; sourceTree = "<group>"; };
 		130408DE1DBA96F200E44AC6 /* reviews_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reviews_response.json; sourceTree = "<group>"; };
+		130408E21DBAAA4600E44AC6 /* YLPClient+Reviews.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "YLPClient+Reviews.h"; sourceTree = "<group>"; };
+		130408E31DBAAA4600E44AC6 /* YLPClient+Reviews.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "YLPClient+Reviews.m"; sourceTree = "<group>"; };
+		130408E61DBAB04400E44AC6 /* YLPBusinessReviews.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YLPBusinessReviews.h; sourceTree = "<group>"; };
+		130408E71DBAB04400E44AC6 /* YLPBusinessReviews.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YLPBusinessReviews.m; sourceTree = "<group>"; };
 		130408EC1DBC0D7B00E44AC6 /* YelpAPITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "YelpAPITests-Bridging-Header.h"; sourceTree = "<group>"; };
 		130408ED1DBC0D7B00E44AC6 /* YLPReviewsClientTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YLPReviewsClientTestCase.swift; sourceTree = "<group>"; };
 		134DA8B91CBF2484008DD68F /* YelpAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YelpAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -260,6 +268,8 @@
 				134DA9831CBF253B008DD68F /* YLPClient+Business.m */,
 				134DA9841CBF253B008DD68F /* YLPClient+PhoneSearch.h */,
 				134DA9851CBF253B008DD68F /* YLPClient+PhoneSearch.m */,
+				130408E21DBAAA4600E44AC6 /* YLPClient+Reviews.h */,
+				130408E31DBAAA4600E44AC6 /* YLPClient+Reviews.m */,
 				134DA9861CBF253B008DD68F /* YLPClient+Search.h */,
 				134DA9871CBF253B008DD68F /* YLPClient+Search.m */,
 				134DA9881CBF253B008DD68F /* YLPClient.h */,
@@ -294,6 +304,8 @@
 			children = (
 				134DA9961CBF253B008DD68F /* YLPBusiness.h */,
 				134DA9971CBF253B008DD68F /* YLPBusiness.m */,
+				130408E61DBAB04400E44AC6 /* YLPBusinessReviews.h */,
+				130408E71DBAB04400E44AC6 /* YLPBusinessReviews.m */,
 				134DA9981CBF253B008DD68F /* YLPCategory.h */,
 				134DA9991CBF253B008DD68F /* YLPCategory.m */,
 				134DA9A41CBF253B008DD68F /* YLPLocation.h */,
@@ -439,7 +451,9 @@
 				134DA9D01CBF253B008DD68F /* YLPLocation.h in Headers */,
 				134DA9B71CBF253B008DD68F /* YLPClient.h in Headers */,
 				134DA9C21CBF253B008DD68F /* YLPBusiness.h in Headers */,
+				130408E81DBAB04400E44AC6 /* YLPBusinessReviews.h in Headers */,
 				134DA9B11CBF253B008DD68F /* YLPClient+Business.h in Headers */,
+				130408E41DBAAA4600E44AC6 /* YLPClient+Reviews.h in Headers */,
 				134DA9B31CBF253B008DD68F /* YLPClient+PhoneSearch.h in Headers */,
 				13BE49641D2037070002262E /* YLPQuery.h in Headers */,
 				13BE49671D203E000002262E /* YLPQueryPrivate.h in Headers */,
@@ -717,6 +731,8 @@
 			files = (
 				134DA9BC1CBF253B008DD68F /* YLPCoordinate.m in Sources */,
 				134DA9C31CBF253B008DD68F /* YLPBusiness.m in Sources */,
+				130408E51DBAAA4600E44AC6 /* YLPClient+Reviews.m in Sources */,
+				130408E91DBAB04400E44AC6 /* YLPBusinessReviews.m in Sources */,
 				134DA9B21CBF253B008DD68F /* YLPClient+Business.m in Sources */,
 				134DA9DA1CBF253B008DD68F /* YLPSearch.m in Sources */,
 				13BE49651D2037070002262E /* YLPQuery.m in Sources */,

--- a/YelpAPITests/Client/YLPClientTestCaseBase.h
+++ b/YelpAPITests/Client/YLPClientTestCaseBase.h
@@ -6,7 +6,8 @@
 //
 //
 #import <XCTest/XCTest.h>
-#import "YLPClient.h"
+
+@class YLPClient;
 
 @interface YLPClientTestCaseBase : XCTestCase
 
@@ -15,14 +16,5 @@
 @property (nonatomic, copy) NSString *defaultResource;
 
 - (NSDictionary *)loadExpectedResponse:(NSString *)resource;
-
-@end
-
-@interface YLPClient (Testing)
-
-- (NSURLRequest *)requestWithPath:(NSString *)path;
-- (NSURLRequest *)requestWithPath:(NSString *)path params:(NSDictionary *)params;
-
-- (void)queryWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSDictionary *jsonResponse, NSError *error))completionHandler;
 
 @end

--- a/YelpAPITests/Client/YLPPhoneSearchClientTestCase.m
+++ b/YelpAPITests/Client/YLPPhoneSearchClientTestCase.m
@@ -11,6 +11,7 @@
 #import <OHHTTPStubs/OHPathHelpers.h>
 #import <XCTest/XCTest.h>
 #import "YLPBusiness.h"
+#import "YLPClientPrivate.h"
 #import "YLPClient+PhoneSearch.h"
 #import "YLPCoordinate.h"
 #import "YLPSearch.h"

--- a/YelpAPITests/Client/YLPReviewsClientTestCase.swift
+++ b/YelpAPITests/Client/YLPReviewsClientTestCase.swift
@@ -6,12 +6,46 @@
 //
 //
 
+import OHHTTPStubs
 import XCTest
 
 class YLPReviewsClientTestCase: YLPClientTestCaseBase {
     override func setUp() {
         super.setUp()
         defaultResource = "reviews_response.json"
+    }
+
+    func testGetReviews() {
+        let expect = expectation(description: "Test that reviews were returned.")
+
+        OHHTTPStubs.stubRequests(passingTest: { $0.url?.host == kYLPAPIHost }) { _ in
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile(self.defaultResource, type(of: self))!,
+                                       statusCode: 200,
+                                       headers: ["Content-Type": "application/json"])
+        }
+
+        client.reviewsForBusiness(withId: "bizId") { (reviews, error) in
+            XCTAssertNil(error)
+            guard let reviews = reviews else {
+                XCTFail("Nil business reviews from reviews lookup")
+                return
+            }
+            XCTAssertEqual(reviews.reviews.count, 3)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testBusinessReviewsParsing() {
+        guard let reviewsResponseJSON = loadExpectedResponse(defaultResource) else {
+            XCTFail("Could not load reviews JSON")
+            return
+        }
+
+        let reviews = YLPBusinessReviews(dictionary: reviewsResponseJSON)
+        XCTAssertEqual(reviews.total, 3)
+        XCTAssertEqual(reviews.reviews.count, 3)
     }
 
     func testReviewParsing() {

--- a/YelpAPITests/Client/YLPReviewsClientTestCase.swift
+++ b/YelpAPITests/Client/YLPReviewsClientTestCase.swift
@@ -1,0 +1,39 @@
+//
+//  YLPReviewsClientTestCase.swift
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 10/22/16.
+//
+//
+
+import XCTest
+
+class YLPReviewsClientTestCase: YLPClientTestCaseBase {
+    override func setUp() {
+        super.setUp()
+        defaultResource = "reviews_response.json"
+    }
+
+    func testReviewParsing() {
+        guard let reviewsResponseJSON = loadExpectedResponse(defaultResource),
+              let reviewsJSONArray = reviewsResponseJSON["reviews"] as? [[String: Any]],
+              let reviewJSON = reviewsJSONArray.first else {
+            XCTFail("Could not load review JSON")
+            return
+        }
+
+        let review = YLPReview(dictionary: reviewJSON)
+        XCTAssertEqual(review.rating, 5)
+        XCTAssert(review.excerpt.hasPrefix("Went back again to this place since"))
+
+        let expectedDate = DateComponents(calendar: Calendar(identifier: .gregorian),
+                                          timeZone: TimeZone(abbreviation: "PST"),
+                                          year: 2016, month: 8, day: 29,
+                                          hour: 0, minute: 41, second: 13).date!
+        XCTAssertEqual(review.timeCreated, expectedDate)
+
+        let user = review.user
+        XCTAssertEqual(user.name, "Ella A.")
+        XCTAssertNotNil(user.imageURL)
+    }
+}

--- a/YelpAPITests/Responses/reviews_response.json
+++ b/YelpAPITests/Responses/reviews_response.json
@@ -1,0 +1,35 @@
+{
+  "reviews": [
+    {
+      "rating": 5,
+      "user": {
+        "image_url": "https://s3-media3.fl.yelpcdn.com/photo/iwoAD12zkONZxJ94ChAaMg/o.jpg",
+        "name": "Ella A."
+      },
+      "text": "Went back again to this place since the last time i visited the bay area 5 months ago, and nothing has changed. Still the sketchy Mission, Still the cashier...",
+      "time_created": "2016-08-29 00:41:13",
+      "url": "https://www.yelp.com/biz/la-palma-mexicatessen-san-francisco?hrid=hp8hAJ-AnlpqxCCu7kyCWA&adjust_creative=0sidDfoTIHle5vvHEBvF0w&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_reviews&utm_source=0sidDfoTIHle5vvHEBvF0w"
+    },
+    {
+      "rating": 4,
+      "user": {
+        "image_url": null,
+        "name": "Yanni L."
+      },
+      "text": "The \"restaurant\" is inside a small deli so there is no sit down area. Just grab and go.\n\nInside, they sell individually packaged ingredients so that you can...",
+      "time_created": "2016-09-28 08:55:29",
+      "url": "https://www.yelp.com/biz/la-palma-mexicatessen-san-francisco?hrid=fj87uymFDJbq0Cy5hXTHIA&adjust_creative=0sidDfoTIHle5vvHEBvF0w&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_reviews&utm_source=0sidDfoTIHle5vvHEBvF0w"
+    },
+    {
+      "rating": 4,
+      "user": {
+        "image_url": null,
+        "name": "Suavecito M."
+      },
+      "text": "Dear Mission District,\n\nI miss you and your many delicious late night food establishments and vibrant atmosphere.  I miss the way you sound and smell on a...",
+      "time_created": "2016-08-10 07:56:44",
+      "url": "https://www.yelp.com/biz/la-palma-mexicatessen-san-francisco?hrid=m_tnQox9jqWeIrU87sN-IQ&adjust_creative=0sidDfoTIHle5vvHEBvF0w&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_reviews&utm_source=0sidDfoTIHle5vvHEBvF0w"
+    }
+  ],
+  "total": 3
+}

--- a/YelpAPITests/YelpAPITests-Bridging-Header.h
+++ b/YelpAPITests/YelpAPITests-Bridging-Header.h
@@ -1,0 +1,8 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "YelpAPI.h"
+#import "YLPResponsePrivate.h"
+
+#import "YLPClientTestCaseBase.h"


### PR DESCRIPTION
(Based off #48)

The v2 API included reviews in business objects, but for the v3 API they're accessed via a separate endpoint. This change updates `YLPReview` from its API v2 format to the v3 format and adds an extension to `YLPClient` to allow review lookups for a business.

I wrote the tests for this in Swift, because Swift is fun and it helps us ensure this library is nicely compatible with Swift.