### PR TITLE
Fix optional fields to handle NSNull

### DIFF
--- a/Classes/Response/NSDictionary+YLPUtils.m
+++ b/Classes/Response/NSDictionary+YLPUtils.m
@@ -1,0 +1,21 @@
+//
+//  NSDictionary+YLPUtils.m
+//  YelpAPI
+//
+//  Created by Steven Sheldon on 11/17/16.
+//
+//
+
+#import "YLPResponsePrivate.h"
+
+@implementation NSDictionary (YLPUtils)
+
+- (id)ylp_objectMaybeNullForKey:(id)key {
+    id obj = self[key];
+    if ([obj isEqual:[NSNull null]]) {
+        return nil;
+    }
+    return obj;
+}
+
+@end

--- a/Classes/Response/YLPBusiness.h
+++ b/Classes/Response/YLPBusiness.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, copy) NSArray<YLPCategory *> *categories;
 
-@property (nonatomic, readonly, copy) YLPLocation *location;
+@property (nonatomic, readonly) YLPLocation *location;
 
 @end
 

--- a/Classes/Response/YLPBusiness.m
+++ b/Classes/Response/YLPBusiness.m
@@ -23,8 +23,9 @@
         _reviewCount = [businessDict[@"review_count"] integerValue];
         
         _name = businessDict[@"name"];
-        _phone = businessDict[@"phone"];
         _identifier = businessDict[@"id"];
+        NSString *phone = [businessDict ylp_objectMaybeNullForKey:@"phone"];
+        _phone = phone.length > 0 ? phone : nil;
         
         _categories = [self.class categoriesFromJSONArray:businessDict[@"categories"]];
         YLPCoordinate *coordinate = [self.class coordinateFromJSONDictionary:businessDict[@"coordinates"]];
@@ -42,8 +43,8 @@
 }
 
 + (YLPCoordinate *)coordinateFromJSONDictionary:(NSDictionary *)coordinatesDict {
-    NSNumber *latitude = coordinatesDict[@"latitude"];
-    NSNumber *longitude = coordinatesDict[@"longitude"];
+    NSNumber *latitude = [coordinatesDict ylp_objectMaybeNullForKey:@"latitude"];
+    NSNumber *longitude = [coordinatesDict ylp_objectMaybeNullForKey:@"longitude"];
     if (latitude && longitude) {
         return [[YLPCoordinate alloc] initWithLatitude:[latitude doubleValue]
                                              longitude:[longitude doubleValue]];

--- a/Classes/Response/YLPLocation.h
+++ b/Classes/Response/YLPLocation.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *address;
 
-@property (nonatomic, readonly, nullable, copy) YLPCoordinate *coordinate;
+@property (nonatomic, readonly, nullable) YLPCoordinate *coordinate;
 
 @end
 

--- a/Classes/Response/YLPLocation.m
+++ b/Classes/Response/YLPLocation.m
@@ -8,6 +8,7 @@
 
 #import "YLPLocation.h"
 #import "YLPCoordinate.h"
+#import "YLPResponsePrivate.h"
 
 @implementation YLPLocation
 
@@ -20,7 +21,11 @@
         
         NSMutableArray *address = [NSMutableArray array];
         for (NSString *addressKey in @[@"address1", @"address2", @"address3"]) {
-            [address addObject:location[addressKey]];
+            NSString *addressLine = [location ylp_objectMaybeNullForKey:addressKey];
+            // Skip empty lines
+            if (addressLine.length > 0) {
+                [address addObject:addressLine];
+            }
         }
         _address = address;
 

--- a/Classes/Response/YLPResponsePrivate.h
+++ b/Classes/Response/YLPResponsePrivate.h
@@ -15,6 +15,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface NSDictionary<KeyType, ObjectType> (YLPUtils)
+- (nullable ObjectType)ylp_objectMaybeNullForKey:(KeyType)key;
+@end
+
 @interface YLPBusiness ()
 - (instancetype)initWithDictionary:(NSDictionary *)businessDict;
 @end

--- a/Classes/Response/YLPReview.h
+++ b/Classes/Response/YLPReview.h
@@ -14,14 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YLPReview : NSObject
 
-@property(nonatomic, readonly, copy) NSString *identifier;
 @property(nonatomic, readonly, copy) NSString *excerpt;
 
 @property(nonatomic, readonly, copy) NSDate *timeCreated;
 
 @property(nonatomic, readonly) double rating;
 
-@property(nonatomic, readonly, copy) YLPUser *user;
+@property(nonatomic, readonly) YLPUser *user;
 
 @end
 

--- a/Classes/Response/YLPUser.m
+++ b/Classes/Response/YLPUser.m
@@ -7,18 +7,15 @@
 //
 
 #import "YLPUser.h"
+#import "YLPResponsePrivate.h"
 
 @implementation YLPUser
 
 - (instancetype)initWithDictionary:(NSDictionary *)userDict {
     if (self = [super init]) {
         _name = userDict[@"name"];
-        id imageURL = userDict[@"image_url"];
-        if (imageURL && ![imageURL isEqual:[NSNull null]]) {
-            _imageURL = [NSURL URLWithString:imageURL];
-        } else {
-            _imageURL = nil;
-        }
+        NSString *imageURLString = [userDict ylp_objectMaybeNullForKey:@"image_url"];
+        _imageURL = imageURLString ? [NSURL URLWithString:imageURLString] : nil;
     }
     return self;
 }

--- a/YelpAPI.xcodeproj/project.pbxproj
+++ b/YelpAPI.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		13BE49651D2037070002262E /* YLPQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE49631D2037070002262E /* YLPQuery.m */; };
 		13BE49671D203E000002262E /* YLPQueryPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 13BE49661D203D6D0002262E /* YLPQueryPrivate.h */; };
 		13BE49691D2056C70002262E /* YLPQueryTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE49681D2056C70002262E /* YLPQueryTestCase.m */; };
+		13D8661E1DDE402D0051C1A0 /* NSDictionary+YLPUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 13D8661C1DDE402D0051C1A0 /* NSDictionary+YLPUtils.m */; };
 		2938CD961893BBC9FB96A9A1 /* Pods_YelpAPI_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 940F602628A3DC514173CCBB /* Pods_YelpAPI_Example.framework */; };
 		4D1C48BD7C6555E51CC7DB7B /* Pods_YelpAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2DA62F3AB4E9CED8852687 /* Pods_YelpAPI.framework */; };
 		E649614BDA7B6533CF642746 /* Pods_YelpAPITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C801DC94688578238D1B1D4D /* Pods_YelpAPITests.framework */; };
@@ -175,6 +176,7 @@
 		13BE49631D2037070002262E /* YLPQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YLPQuery.m; sourceTree = "<group>"; };
 		13BE49661D203D6D0002262E /* YLPQueryPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YLPQueryPrivate.h; sourceTree = "<group>"; };
 		13BE49681D2056C70002262E /* YLPQueryTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YLPQueryTestCase.m; sourceTree = "<group>"; };
+		13D8661C1DDE402D0051C1A0 /* NSDictionary+YLPUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+YLPUtils.m"; sourceTree = "<group>"; };
 		2E0DC5F670084B64ECD1DB90 /* Pods-YelpAPI_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPI_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPI_Example/Pods-YelpAPI_Example.release.xcconfig"; sourceTree = "<group>"; };
 		57A6A7BEE7B82D4C749B5DA5 /* Pods-YelpAPITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YelpAPITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-YelpAPITests/Pods-YelpAPITests.release.xcconfig"; sourceTree = "<group>"; };
 		8A2DA62F3AB4E9CED8852687 /* Pods_YelpAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YelpAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -302,6 +304,7 @@
 		134DA9951CBF253B008DD68F /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				13D8661C1DDE402D0051C1A0 /* NSDictionary+YLPUtils.m */,
 				134DA9961CBF253B008DD68F /* YLPBusiness.h */,
 				134DA9971CBF253B008DD68F /* YLPBusiness.m */,
 				130408E61DBAB04400E44AC6 /* YLPBusinessReviews.h */,
@@ -735,6 +738,7 @@
 				130408E91DBAB04400E44AC6 /* YLPBusinessReviews.m in Sources */,
 				134DA9B21CBF253B008DD68F /* YLPClient+Business.m in Sources */,
 				134DA9DA1CBF253B008DD68F /* YLPSearch.m in Sources */,
+				13D8661E1DDE402D0051C1A0 /* NSDictionary+YLPUtils.m in Sources */,
 				13BE49651D2037070002262E /* YLPQuery.m in Sources */,
 				134DA9B41CBF253B008DD68F /* YLPClient+PhoneSearch.m in Sources */,
 				134DA9D81CBF253B008DD68F /* YLPReview.m in Sources */,

--- a/YelpAPITests/Client/YLPBusinessClientTestCase.m
+++ b/YelpAPITests/Client/YLPBusinessClientTestCase.m
@@ -15,6 +15,7 @@
 #import "YLPClient+Business.h"
 #import "YLPCoordinate.h"
 #import "YLPLocation.h"
+#import "YLPResponsePrivate.h"
 #import "YLPReview.h"
 #import "YLPUser.h"
 #import "YLPClientTestCaseBase.h"
@@ -121,6 +122,23 @@
         
     }];
     [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+- (void)testLocationParsingNullAddressLine {
+    NSDictionary *locationJSON = @{
+        @"address1": @"549 Castro St",
+        @"address2": [NSNull null],
+        @"address3": @"",
+        @"city": @"San Francisco",
+        @"country": @"US",
+        @"state": @"CA",
+        @"zip_code": @"94114",
+    };
+    YLPLocation *location = [[YLPLocation alloc] initWithDictionary:locationJSON coordinate:nil];
+
+    // Test that null and empty lines are properly stripped from the address
+    XCTAssertEqual(location.address.count, 1);
+    XCTAssertEqualObjects(location.address, @[@"549 Castro St"]);
 }
 
 @end

--- a/YelpAPITests/Client/YLPReviewsClientTestCase.swift
+++ b/YelpAPITests/Client/YLPReviewsClientTestCase.swift
@@ -70,4 +70,14 @@ class YLPReviewsClientTestCase: YLPClientTestCaseBase {
         XCTAssertEqual(user.name, "Ella A.")
         XCTAssertNotNil(user.imageURL)
     }
+
+    func testUserParsingNullImage() {
+        let userJSON: [String: Any] = [
+            "name": "Ella A.",
+            "image_url": NSNull(),
+        ]
+
+        let user = YLPUser(dictionary: userJSON)
+        XCTAssertNil(user.imageURL)
+    }
 }


### PR DESCRIPTION
For certain optional fields, the API will explicitly return `null`, which ends up as `NSNull` and if not properly handled it will violate our type annotations, as described in #52.

This change audits the fields which may be null and handles the `NSNull` accordingly with the help of a dictionary utility method.

While auditing for nullability, I also noticed some properties marked as `copy` for objects that are not actually `NSCopying`, so I cleaned those up along the way.

This fixed #52.