### PR TITLE
Remove business params that aren't supported in v3

### DIFF
--- a/Classes/Client/YLPClient+Business.h
+++ b/Classes/Client/YLPClient+Business.h
@@ -16,14 +16,8 @@ typedef void(^YLPBusinessCompletionHandler)(YLPBusiness * _Nullable business, NS
 @interface YLPClient (Business)
 
 - (void)businessWithId:(NSString *)businessId
-        completionHandler:(YLPBusinessCompletionHandler)completionHandler;
+     completionHandler:(YLPBusinessCompletionHandler)completionHandler;
 
-- (void)businessWithId:(NSString *)businessId
-              countryCode:(nullable NSString *)countryCode
-             languageCode:(nullable NSString *)languageCode
-           languageFilter:(BOOL)languageFilter
-              actionLinks:(BOOL)actionLinks
-        completionHandler:(YLPBusinessCompletionHandler)completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Client/YLPClient+Business.m
+++ b/Classes/Client/YLPClient+Business.m
@@ -13,44 +13,14 @@
 
 @implementation YLPClient (Business)
 
-- (NSURLRequest *)businessRequestWithId:(NSString *)businessId
-                                 params:(NSDictionary *)params {
-    
+- (NSURLRequest *)businessRequestWithId:(NSString *)businessId {
     NSString *businessPath = [@"/v3/businesses/" stringByAppendingString:businessId];
-    return [self requestWithPath:businessPath params:params];
+    return [self requestWithPath:businessPath];
 }
 
 - (void)businessWithId:(NSString *)businessId
-        completionHandler:(void (^)(YLPBusiness *business, NSError *error))completionHandler {
-    
-    [self businessWithId:businessId params:nil completionHandler:completionHandler];
-}
-
-- (void)businessWithId:(NSString *)businessId
-              countryCode:(NSString *)countryCode
-             languageCode:(NSString *)languageCode
-           languageFilter:(BOOL)languageFilter
-              actionLinks:(BOOL)actionLinks
-        completionHandler:(YLPBusinessCompletionHandler)completionHandler {
-    
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{
-                                    @"lang_filter": @(languageFilter),
-                                    @"actionlinks": @(actionLinks)
-                                    }];
-    if (countryCode) {
-        params[@"cc"] = countryCode;
-    }
-    if (languageCode) {
-        params[@"lang"] = languageCode;
-    }
-    [self businessWithId:businessId params:params completionHandler:completionHandler];
-}
-
-- (void)businessWithId:(NSString *)businessId
-                   params:(NSDictionary *)params
-        completionHandler:(YLPBusinessCompletionHandler)completionHandler {
-    
-    NSURLRequest *req = [self businessRequestWithId:businessId params:params];
+     completionHandler:(void (^)(YLPBusiness *business, NSError *error))completionHandler {
+    NSURLRequest *req = [self businessRequestWithId:businessId];
     [self queryWithRequest:req completionHandler:^(NSDictionary *responseDict, NSError *error) {
         if (error) {
             completionHandler(nil, error);

--- a/YelpAPITests/Client/YLPBusinessClientTestCase.m
+++ b/YelpAPITests/Client/YLPBusinessClientTestCase.m
@@ -25,7 +25,7 @@
 
 @interface YLPClient (BusinessClientTest)
 
-- (void)businessWithId:(NSString *)businessId params:(NSDictionary *)params completionHandler:(void (^)(YLPBusiness *business, NSError *error))completionHandler;
+- (NSURLRequest *)businessRequestWithId:(NSString *)businessId;
 
 @end
 
@@ -36,21 +36,10 @@
     self.defaultResource = @"business_response.json";
 }
 
-- (id)mockBusinessRequestWithAllArgs {
-    id mockBusinessRequestWithAllArgs = OCMPartialMock(self.client);
-    OCMStub([mockBusinessRequestWithAllArgs businessWithId:[OCMArg any] params:[OCMArg any] completionHandler:[OCMArg any]]);
-    return mockBusinessRequestWithAllArgs;
-}
-
-- (void)testNullParams {
-    [self.client businessWithId:@"gary-danko" countryCode:@"" languageCode:@"" languageFilter:NO actionLinks:NO completionHandler:^(YLPBusiness *business, NSError *error) {}];
-    [self.client businessWithId:@"gary-danko-san-francisco" countryCode:nil languageCode:nil languageFilter:NO actionLinks:NO completionHandler:^(YLPBusiness *business, NSError *error) {}];
-}
 - (void)testBusinessRequestWithId {
-    id mockBusinessRequestWithIdWithAllArgs = [self mockBusinessRequestWithAllArgs];
-    [self.client businessWithId:@"bogusBusinessId" completionHandler:^(YLPBusiness *business, NSError *error) {}];
-    
-    OCMVerify([mockBusinessRequestWithIdWithAllArgs businessWithId:@"bogusBusinessId" params:nil completionHandler:[OCMArg any]]);
+    NSURLRequest *request = [self.client businessRequestWithId:@"bogusBusinessId"];
+    // Assert that the business id is inserted into the path properly
+    XCTAssertEqualObjects(request.URL.path, @"/v3/businesses/bogusBusinessId");
 }
 
 - (void)testBusinessRequestResult {


### PR DESCRIPTION
The v2 API accepted 4 optional parameters on its business endpoint that aren't used in the v3 API. I forgot to remove them in #48.

To test, I verified the tests are passing and ran the sample app.