### PR TITLE
Don't parse business image URL if it's an empty string

### DIFF
--- a/Classes/Response/YLPBusiness.h
+++ b/Classes/Response/YLPBusiness.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YLPBusiness : NSObject
 
+@property (nonatomic, getter=isClosed, readonly) BOOL closed;
+
 @property (nonatomic, readonly, nullable, copy) NSURL *imageURL;
 @property (nonatomic, readonly, copy) NSURL *URL;
 

--- a/Classes/Response/YLPBusiness.m
+++ b/Classes/Response/YLPBusiness.m
@@ -16,6 +16,8 @@
 
 - (instancetype)initWithDictionary:(NSDictionary *)businessDict {
     if (self = [super init]) {
+        _closed = [businessDict[@"is_closed"] boolValue];
+
         _URL = [[NSURL alloc] initWithString:businessDict[@"url"]];
         NSString *imageURLString = [businessDict ylp_objectMaybeNullForKey:@"image_url"];
         _imageURL = imageURLString.length > 0 ? [[NSURL alloc] initWithString:imageURLString] : nil;

--- a/Classes/Response/YLPBusiness.m
+++ b/Classes/Response/YLPBusiness.m
@@ -17,7 +17,8 @@
 - (instancetype)initWithDictionary:(NSDictionary *)businessDict {
     if (self = [super init]) {
         _URL = [[NSURL alloc] initWithString:businessDict[@"url"]];
-        _imageURL = businessDict[@"image_url"] ? [[NSURL alloc] initWithString:businessDict[@"image_url"]] : nil;
+        NSString *imageURLString = [businessDict ylp_objectMaybeNullForKey:@"image_url"];
+        _imageURL = imageURLString.length > 0 ? [[NSURL alloc] initWithString:imageURLString] : nil;
         
         _rating = [businessDict[@"rating"] doubleValue];
         _reviewCount = [businessDict[@"review_count"] integerValue];


### PR DESCRIPTION
One last pseudo-nullable field that hadn't been handled. image_url used to be nullable, but now we return an empty string for missing images. Parsing this into an NSURL results in a weird URL. To fix this, I catch an empty URL string and set a nil NSURL instead.

Also, I found that we just added support for is_closed, so that field doesn't need to be removed. I added it back.