### PR TITLE
Add remaining YLPQuery parameters #60

### DIFF
--- a/Classes/Request/YLPQuery.h
+++ b/Classes/Request/YLPQuery.h
@@ -33,9 +33,29 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, nonatomic, nullable) NSString *term;
 
 /**
+ Search price ("1", "2", "3", or "4"). If term is nil, everything will be searched.
+ */
+@property (copy, nonatomic, nullable) NSString *price;
+
+/**
+ Search locale, language to return the business information in.
+ */
+@property (copy, nonatomic, nullable) NSString *locale;
+
+/**
  Number of business results to return. If 0, the API maximum of 20 results will be returned.
  */
 @property (assign, nonatomic) NSUInteger limit;
+
+/**
+ An integer represending the Unix time in the same timezone of the search location. If specified, it will return business open at the given time.
+ */
+@property (assign, nonatomic) NSUInteger openAt;
+
+/**
+ Whether to exclusively search for businesses open now. If openAt has value > 0 then only openAt is used.
+ */
+@property (assign, nonatomic) BOOL openNow;
 
 /**
  Amount by which to offset the list of returned business. The default is 0.
@@ -61,6 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
  Whether to exclusively search for businesses with deals.
  */
 @property (assign, nonatomic) BOOL dealsFilter;
+
+/**
+ Whether to exclusively search for businesses that are hot and new.
+ */
+@property (assign, nonatomic) BOOL hotAndNewFilter;
 
 @end
 

--- a/Classes/Request/YLPQuery.m
+++ b/Classes/Request/YLPQuery.m
@@ -60,8 +60,17 @@
     if (self.term) {
         params[@"term"] = self.term;
     }
+    if (self.price) {
+        params[@"price"] = self.price;
+    }
+    if (self.locale) {
+        params[@"locale"] = self.locale;
+    }
     if (self.limit) {
         params[@"limit"] = @(self.limit);
+    }
+    if (self.openAt > 0) {
+        params[@"open_at"] = @(self.openAt);
     }
     if (self.offset) {
         params[@"offset"] = @(self.offset);
@@ -75,8 +84,15 @@
     if (self.radiusFilter > 0) {
         params[@"radius"] = @(self.radiusFilter);
     }
-    if (self.dealsFilter) {
+    if (self.dealsFilter && self.hotAndNewFilter) {
+        params[@"attributes"] = @"deals,hot_and_new";
+    } else if (self.dealsFilter) {
         params[@"attributes"] = @"deals";
+    } else if (self.hotAndNewFilter) {
+        params[@"attributes"] = @"hot_and_new";
+    }
+    if (self.openNow && self.openAt == 0) {
+        params[@"open_now"] = @(true);
     }
 
     return params;


### PR DESCRIPTION
Added the remaining parameters to the YLPQuery. 

If open_at and open_now are used at the same time only open_at will be added to the params.