### PR TITLE
Replace OAuth 2 authentication with new API keys

### DIFF
--- a/Classes/Client/YLPClient.h
+++ b/Classes/Client/YLPClient.h
@@ -16,9 +16,7 @@ extern NSString *const kYLPAPIHost;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (void)authorizeWithAppId:(NSString *)appId
-                    secret:(NSString *)secret
-         completionHandler:(void (^)(YLPClient *_Nullable client, NSError *_Nullable error))completionHandler;
+- (instancetype)initWithAPIKey:(NSString *)APIKey;
 
 @end
 

--- a/Classes/Client/YLPClient.m
+++ b/Classes/Client/YLPClient.m
@@ -14,7 +14,7 @@ NSString *const kYLPAPIHost = @"api.yelp.com";
 NSString *const kYLPErrorDomain = @"com.yelp.YelpAPI.ErrorDomain";
 
 @interface YLPClient ()
-@property (strong, nonatomic) NSString *accessToken;
+@property (strong, nonatomic) NSString *APIKey;
 @end
 
 @implementation YLPClient
@@ -23,9 +23,9 @@ NSString *const kYLPErrorDomain = @"com.yelp.YelpAPI.ErrorDomain";
     return nil;
 }
 
-- (instancetype)initWithAccessToken:(NSString *)accessToken {
+- (instancetype)initWithAPIKey:(NSString *)APIKey {
     if (self = [super init]) {
-        _accessToken = accessToken;
+        _APIKey = APIKey;
     }
     return self;
 }
@@ -47,7 +47,7 @@ NSString *const kYLPErrorDomain = @"com.yelp.YelpAPI.ErrorDomain";
 
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:urlComponents.URL];
     request.HTTPMethod = @"GET";
-    NSString *authHeader = [NSString stringWithFormat:@"Bearer %@", self.accessToken];
+    NSString *authHeader = [NSString stringWithFormat:@"Bearer %@", self.APIKey];
     [request setValue:authHeader forHTTPHeaderField:@"Authorization"];
 
     return request;
@@ -91,54 +91,6 @@ NSString *const kYLPErrorDomain = @"com.yelp.YelpAPI.ErrorDomain";
         [queryItems addObject:queryItem];
     }
     return queryItems;
-}
-
-+ (NSCharacterSet *)URLEncodeAllowedCharacters {
-    // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
-    NSMutableCharacterSet *allowedCharacters = [[NSMutableCharacterSet alloc] init];
-    [allowedCharacters addCharactersInRange:NSMakeRange((NSUInteger)'A', 26)];
-    [allowedCharacters addCharactersInRange:NSMakeRange((NSUInteger)'a', 26)];
-    [allowedCharacters addCharactersInRange:NSMakeRange((NSUInteger)'0', 10)];
-    [allowedCharacters addCharactersInString:@"-._~"];
-    return allowedCharacters;
-}
-
-#pragma mark Authorization
-
-+ (NSURLRequest *)authRequestWithAppId:(NSString *)appId secret:(NSString *)secret {
-    NSURLComponents *urlComponents = [[NSURLComponents alloc] init];
-    urlComponents.scheme = @"https";
-    urlComponents.host = kYLPAPIHost;
-    urlComponents.path = @"/oauth2/token";
-
-    NSCharacterSet *allowedCharacters = [self URLEncodeAllowedCharacters];
-    NSString *body = [NSString stringWithFormat:@"grant_type=client_credentials&client_id=%@&client_secret=%@",
-                      [appId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters],
-                      [secret stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters]];
-    NSData *bodyData = [body dataUsingEncoding:NSUTF8StringEncoding];
-
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:urlComponents.URL];
-    request.HTTPMethod = @"POST";
-    request.HTTPBody = bodyData;
-    [request setValue:[NSString stringWithFormat:@"%zd", bodyData.length] forHTTPHeaderField:@"Content-Length"];
-    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
-
-    return request;
-}
-
-+ (void)authorizeWithAppId:(NSString *)appId
-                    secret:(NSString *)secret
-         completionHandler:(void (^)(YLPClient *client, NSError *error))completionHandler {
-    NSURLRequest *request = [self authRequestWithAppId:appId secret:secret];
-    [self queryWithRequest:request completionHandler:^(NSDictionary *jsonResponse, NSError *error) {
-        if (error) {
-            completionHandler(nil, error);
-        } else {
-            NSString *accessToken = jsonResponse[@"access_token"];
-            YLPClient *client = [[YLPClient alloc] initWithAccessToken:accessToken];
-            completionHandler(client, nil);
-        }
-    }];
 }
 
 @end

--- a/Classes/Client/YLPClientPrivate.h
+++ b/Classes/Client/YLPClientPrivate.h
@@ -13,14 +13,9 @@ extern NSString *const kYLPErrorDomain;
 
 @interface YLPClient ()
 
-- (instancetype)initWithAccessToken:(NSString *)accessToken;
-
 - (NSURLRequest *)requestWithPath:(NSString *)path;
 - (NSURLRequest *)requestWithPath:(NSString *)path params:(nullable NSDictionary *)params;
 - (void)queryWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSDictionary *responseDict, NSError *error))completionHandler;
-
-+ (NSCharacterSet *)URLEncodeAllowedCharacters;
-+ (NSURLRequest *)authRequestWithAppId:(NSString *)appId secret:(NSString *)secret;
 
 @end
 

--- a/Example/YelpAPI/YLPAppDelegate.m
+++ b/Example/YelpAPI/YLPAppDelegate.m
@@ -24,13 +24,8 @@
 #pragma mark UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    #warning Fill in the API keys below with your developer v3 keys.
-    [YLPClient authorizeWithAppId:@"" secret:@"" completionHandler:^(YLPClient *client, NSError *error) {
-        self.client = client;
-        if (!client) {
-            NSLog(@"Authentication failed: %@", error);
-        }
-    }];
+    #warning Fill in the API key below with your developer v3 key.
+    self.client = [[YLPClient alloc] initWithAPIKey:@""];
 
     return YES;
 }

--- a/YelpAPI.podspec
+++ b/YelpAPI.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "YelpAPI"
-  s.version          = "2.0.0"
+  s.version          = "3.0.0"
   s.summary          = "Objective-C client library for accessing the Yelp Public API."
 
   s.description      = <<-DESC

--- a/YelpAPITests/Client/YLPClientTestCase.m
+++ b/YelpAPITests/Client/YLPClientTestCase.m
@@ -98,16 +98,9 @@
     NSURLRequest *request = [self.client requestWithPath:self.bogusTestPath];
 
     XCTAssertEqualObjects(request.HTTPMethod, @"GET");
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Authorization"], @"Bearer accessToken");
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Authorization"], @"Bearer API_KEY");
     XCTAssertEqualObjects(request.URL.absoluteString, @"https://api.yelp.com/bogusPath");
     XCTAssertEqual(request.HTTPBody.length, 0);
-}
-
-- (void)testURLEncode {
-    NSCharacterSet *allowedCharacters = [YLPClient URLEncodeAllowedCharacters];
-
-    XCTAssertEqualObjects([@"abAB01_.-~" stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters], @"abAB01_.-~");
-    XCTAssertEqualObjects([@"ab=AB&01" stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters], @"ab%3DAB%2601");
 }
 
 - (NSDictionary<NSString *, NSString *> *)paramsFromQueryString:(NSString *)string {
@@ -120,24 +113,6 @@
     }
 
     return params;
-}
-
-- (void)testAuthRequest {
-    NSURLRequest *authRequest = [YLPClient authRequestWithAppId:@"appId" secret:@"appSecret"];
-    XCTAssertEqualObjects(authRequest.HTTPMethod, @"POST");
-    XCTAssertEqualObjects(authRequest.URL.absoluteString, @"https://api.yelp.com/oauth2/token");
-
-    NSString *body = [[NSString alloc] initWithData:authRequest.HTTPBody encoding:NSUTF8StringEncoding];
-    NSDictionary *bodyParams = [self paramsFromQueryString:body];
-    NSDictionary *expectedBodyParams = @{
-        @"grant_type": @"client_credentials",
-        @"client_id": @"appId",
-        @"client_secret": @"appSecret",
-    };
-    XCTAssertEqualObjects(bodyParams, expectedBodyParams);
-
-    XCTAssertNotNil([authRequest valueForHTTPHeaderField:@"Content-Length"]);
-    XCTAssertEqualObjects([authRequest valueForHTTPHeaderField:@"Content-Type"], @"application/x-www-form-urlencoded");
 }
 
 @end

--- a/YelpAPITests/Client/YLPClientTestCaseBase.m
+++ b/YelpAPITests/Client/YLPClientTestCaseBase.m
@@ -15,7 +15,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.client = [[YLPClient alloc] initWithAccessToken:@"accessToken"];
+    self.client = [[YLPClient alloc] initWithAPIKey:@"API_KEY"];
     self.bogusTestPath = @"/bogusPath";
 }
 


### PR DESCRIPTION
The Fusion API is [switching from its OAuth 2 authentication process to a simpler API key system](https://www.yelp.com/developers/documentation/v3/authentication#where-is-my-client-secret-going). This change updates the creation and signing of a `YLPClient` accordingly! The main impact for us is that a lot of code can be deleted.

The removal of the old authentication methods is a breaking change, so the next version of YelpAPI will be a major version bump to 3.0.

This fixes #73.