### PR TITLE
round radius to int to follow the api call requirements, otherwise returns null result if the radius with a decimal part

### DIFF
--- a/Classes/Request/YLPQuery.m
+++ b/Classes/Request/YLPQuery.m
@@ -73,7 +73,7 @@
         params[@"categories"] = [self.categoryFilter componentsJoinedByString:@","];
     }
     if (self.radiusFilter > 0) {
-        params[@"radius"] = @(self.radiusFilter);
+        params[@"radius"] = @(@(round(self.radiusFilter)).intValue);
     }
     if (self.dealsFilter) {
         params[@"attributes"] = @"deals";


### PR DESCRIPTION
round radius to int to follow the api call requirements, otherwise returns null result if the radius with a decimal part